### PR TITLE
Use git clone to checkout vulcan

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -94,10 +94,7 @@ module.exports = class extends VulcanGenerator {
       return;
     }
     this.log(chalk.green('\nPulling the most up to date git repository... \n'));
-    this.spawnCommandSync('git', ['init']);
-    this.spawnCommandSync('git', ['remote', 'add', 'origin', 'git@github.com:VulcanJS/Vulcan.git']);
-    this.spawnCommandSync('git', ['pull', 'origin', 'master']);
-    this.spawnCommandSync('git', ['remote', 'rm', 'origin']);
+    this.spawnCommandSync('git', ['clone', 'https://github.com/Vulcanjs/Vulcan', '--depth', '1', './'+this.props.appName]);
     this.installDependencies({
       npm: this.props.packageManager === 'npm',
       bower: false,


### PR DESCRIPTION
Instead of init, set origin, pull, rm origin, it should use a simple clone, plus use a grafted commit for extra speed.